### PR TITLE
add secret geojson paste shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -481,6 +481,37 @@ function App() {
         );
       }
     });
+
+    // secret paste polygon from clipboard command
+    var keyMap: { [name: string]: boolean } = {};
+    window.onkeydown = window.onkeyup = async (e) => {
+      keyMap[e.code] = e.type == "keydown";
+      if (e.type != "keydown") return;
+
+      // cntrl + shift + v
+      if (Object.keys(keyMap).length !== 3) return;
+      if (!keyMap["ControlLeft"] || !keyMap["ShiftLeft"] || !keyMap["KeyV"]) {
+        return;
+      }
+
+      try {
+        console.error("secret keyboard shortcut activated!!");
+        if (!navigator?.clipboard) throw new Error("clipboard API unavailable");
+        const clip = await navigator.clipboard.readText();
+        const polygon = JSON.parse(clip);
+        if (polygon?.type !== "Feature") {
+          throw new Error("invalid feature");
+        }
+        if (polygon?.geometry?.type !== "Polygon") {
+          throw new Error("invalid polygon");
+        }
+        const covering = getCovering(regionCoverer, [polygon]);
+        displayCovering(covering);
+      } catch (e) {
+        console.error("clipboard paste failed");
+        console.error(e);
+      }
+    };
   });
 
   return (


### PR DESCRIPTION
add secret 🤫 keyboard shortcut to paste geojson from clipboard.
it must be a single valid `Polygon` feature or it will fail.


example Polygon: https://spelunker.whosonfirst.org/id/85687233/geojson

<img width="473" alt="Screenshot 2024-08-29 at 11 02 13" src="https://github.com/user-attachments/assets/b254a17e-e143-4de5-83d8-5b4546aab2fe">
